### PR TITLE
Fix/patch add message

### DIFF
--- a/pylint_per_file_ignores/__init__.py
+++ b/pylint_per_file_ignores/__init__.py
@@ -62,6 +62,7 @@ class DoSuppress:
         self.linter = linter
         self.message_id_or_symbol = message_id_or_symbol
         self.test_func = test_func
+        self.resolved_symbols = None
 
     def __call__(self, chain, node):
         with Suppress(self.linter) as s:
@@ -83,6 +84,8 @@ class DoSuppress:
         # Therefore here, we try the new attribute name, and fall back to the old
         # version for compatability with <=1.2 and >=1.3
 
+        if self.resolved_symbols is not None:
+            return self.resolved_symbols
         try:
             pylint_messages = self.get_message_definitions(self.message_id_or_symbol)
             the_symbols = [
@@ -95,7 +98,7 @@ class DoSuppress:
             # This can happen due to mismatches of pylint versions and plugin
             # expectations of available messages
             the_symbols = [self.message_id_or_symbol]
-
+        self.resolved_symbols = the_symbols
         return the_symbols
 
     def get_message_definitions(self, message_id_or_symbol):


### PR DESCRIPTION
While running pylint-per-file-ignores on codebase including protobuf generated classes,
some of the warnings could not be ignored.
Example of such warnings: bad-indentation,unused-import,unused-variable,attribute-defined-outside-init

Despite the different checkers being resolved in `get_checker_by_msg`, the DoSuppress isn't called.
This means that some messages are not being generated from within a `visit*` method.
Rather than trying to identify all methods that could generate such warnings, this PR directly patches the checker `add_message()` method.

Tested with Python3.10 & pylint 2.15.0