### PR TITLE
fix(pylint_per_file_ignores/__init__.py): this change fixes loading c…

### DIFF
--- a/pylint_per_file_ignores/__init__.py
+++ b/pylint_per_file_ignores/__init__.py
@@ -263,8 +263,9 @@ def load_configuration(linter: PyLinter) -> None:
     # Loading custom pyproject.toml
     pyproject_file = find_pyproject(linter.current_file)
     if pyproject_file:
-        content = tomllib.load(pyproject_file).open("rb")
-        ignores = {**content["tool"]["pylint-per-file-ignores"]}
+        with open(pyproject_file, "rb") as pyproject_file_object:
+            content = tomllib.load(pyproject_file_object)
+            ignores = {**content["tool"]["pylint-per-file-ignores"]}
 
         for file_path, rules in ignores.items():
             for rule in rules.split(","):


### PR DESCRIPTION
This change fixes: **_AttributeError: 'PosixPath' object has no attribute 'read'_** caused to improper usage of tomllib.load while working with a custom pyproject.toml

The plugin fails on the latest release: v1.3.0

PSB the entire traceback:

```
Traceback (most recent call last):
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/lib/python3.9/site-packages/pylint/__init__.py", line 36, in run_pylint
    PylintRun(argv or sys.argv[1:])
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/lib/python3.9/site-packages/pylint/lint/run.py", line 169, in __init__
    args = _config_initialization(
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/lib/python3.9/site-packages/pylint/config/config_initialization.py", line 113, in _config_initialization
    linter.load_plugin_configuration()
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/lib/python3.9/site-packages/pylint/lint/pylinter.py", line 411, in load_plugin_configuration
    module_or_error.load_configuration(self)
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/lib/python3.9/site-packages/pylint_per_file_ignores/__init__.py", line 266, in load_configuration
    content = tomllib.load(pyproject_file).open("rb")
  File "/home/vignesh/workarea/test2/.nox/pylint-3-9/lib/python3.9/site-packages/tomli/_parser.py", line 59, in load
    b = __fp.read()
AttributeError: 'PosixPath' object has no attribute 'read'
```
This change resolves #76 
