### PR TITLE
Allow rules to be an array

### DIFF
--- a/pylint_per_file_ignores/__init__.py
+++ b/pylint_per_file_ignores/__init__.py
@@ -257,7 +257,9 @@ def load_configuration(linter: PyLinter) -> None:
         )
 
     for file_path, rules in linter.config.per_file_ignores.items():
-        for rule in rules.split(","):
+        if not isinstance(rules, list):
+            rules = rules.split(",")
+        for rule in rules:
             disable_message(linter, rule.strip(), IsFile(file_path, linter))
 
     # Loading custom pyproject.toml
@@ -268,5 +270,7 @@ def load_configuration(linter: PyLinter) -> None:
             ignores = {**content.get("tool", {}).get("pylint-per-file-ignores", {})}
 
         for file_path, rules in ignores.items():
-            for rule in rules.split(","):
+            if not isinstance(rules, list):
+                rules = rules.split(",")
+            for rule in rules:
                 disable_message(linter, rule.strip(), IsFile(file_path, linter))


### PR DESCRIPTION
<!-- Thanks for contributing! 🤠 -->
Enables:
```toml
[tool.pylint-per-file-ignores]
"tests/" = [
    "code-1", # ignoring code-1 because ...
    "code-2", # ignoring code-2 because ...
    "code-3", # ignoring code-3 because ...
]
```

Previously, had to do
```toml
[tool.pylint-per-file-ignores]
# ignoring code-1 because ...
# ignoring code-2 because ...
# ignoring code-3 because ...
"tests/" = "code-1,code-2,code-3"
```

See https://github.com/home-assistant/core/blob/fc915dc1bf341b27f90925df5749278789218822/pyproject.toml#L404-L408
