### PR TITLE
Add regex example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Add list of patterns and codes you would like to ignore.
 Section "MESSAGES CONTROL". Examples:
 
 ```ini
+# .pylintrc
+
+[MESSAGES CONTROL]
+per-file-ignores =
+  .*_test\.py:protected-access # ignore "protected-access" errors in test files ending in "_test.py"
+```
+
+```ini
 # setup.cfg
 
 [pylint.MESSAGES CONTROL]


### PR DESCRIPTION
Adds an example to the README where we are A) using a pylintrc file, and B) using a regex pattern to match all test files ending in "_test.py".

Closes #191

<!-- Thanks for contributing! 🤠 -->
